### PR TITLE
Fix Testimonials page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -120,6 +120,7 @@ code {
 
 .testimonial_content div {
 	margin-left: 2%;
+  width: 100%;
 }
 
 .tutorial_image {

--- a/css/main.css
+++ b/css/main.css
@@ -105,7 +105,9 @@ code {
 
 
 .testimonial_content {
-        display:flex;
+      display:flex;
+      align-items: flex-start;
+      justify-content: center;
 }
 
 .testimonial_content img {
@@ -118,7 +120,6 @@ code {
 
 .testimonial_content div {
 	margin-left: 2%;
-	width: 80%;
 }
 
 .tutorial_image {


### PR DESCRIPTION
Accidentally,  I noticed, that Testimonials page on Chromium/Chrome/Opera does not look good. Images have too big of a vertical margin, so there is too much of free space. (See pictures)
![image](https://user-images.githubusercontent.com/13331189/47969316-0c2f7680-e076-11e8-9a06-0ba2ac17c8a8.png)
![image](https://user-images.githubusercontent.com/13331189/47969262-3df40d80-e075-11e8-9dc9-c18681a33a54.png)
 Firefox seems to display fine. Anyway, my fix should make behaviour identical on all browsers and centerizes text of testimonials with no pictures. 
