### PR TITLE
Fix Sticky Header and add Github Icon

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
     <div class="top-bar" id="main-menu">
       <div class="top-bar-left">
         <ul class="vertical large-horizontal menu">
-          <li class="show-for-large is-logo">
+          <li class="is-logo">
             <a href="{{ site.baseurl }}/">{{ site.title }}</a>
           </li>
           {% for ipage in site.pages %}
@@ -29,7 +29,7 @@
           {% endfor %}
         </ul>
       </div>
-      <div class="top-bar-right show-for-large">
+      <div class="top-bar-right">
         <ul class="horizontal menu">
           <li>
             <a href="https://github.com/precice/precice" target="_blank" data-show-count="false" aria-label="Star precice/precice on GitHub"><i class="fab fa-github fa-fw"></i></a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,33 +1,29 @@
 <header>
-  <nav data-sticky-containter>
-    <div data-sticky data-margin-top="0" data-sticky-on="small">
-
-      <div class="title-bar"  data-responsive-toggle="main-menu" data-hide-for="large" aria-hidden="true">
-        <button class="menu-icon" type="button" data-toggle="main-menu"></button>
-        <div class="title-bar-title">
-          <a href="{{ site.baseurl }}/">{{ site.title }}</a>
-        </div>
+  <nav>
+    <div class="title-bar"  data-responsive-toggle="main-menu" data-hide-for="large" aria-hidden="true">
+      <button class="menu-icon" type="button" data-toggle="main-menu"></button>
+      <div class="title-bar-title">
+        <a href="{{ site.baseurl }}/">{{ site.title }}</a>
       </div>
+    </div>
 
-      <div class="top-bar" id="main-menu">
-        <div class="top-bar-left">
-          <ul class="vertical large-horizontal menu">
-            <li class="show-for-large is-logo">
-              <a href="{{ site.baseurl }}/">{{ site.title }}</a>
-            </li>
-            {% for ipage in site.pages %}
-              {% if ipage.title %}
-                {% if ipage.title !="Home" %}
-                  <li{% if ipage.url == page.url %} class="is-active" {% endif %}>
-                    <a href="{{ ipage.url | prepend: site.baseurl }}">{{ ipage.title }}</a>
-                  </li>
-                {% endif %}
+    <div class="top-bar" id="main-menu">
+      <div class="top-bar-left">
+        <ul class="vertical large-horizontal menu">
+          <li class="show-for-large is-logo">
+            <a href="{{ site.baseurl }}/">{{ site.title }}</a>
+          </li>
+          {% for ipage in site.pages %}
+            {% if ipage.title %}
+              {% if ipage.title !="Home" %}
+                <li{% if ipage.url == page.url %} class="is-active" {% endif %}>
+                  <a href="{{ ipage.url | prepend: site.baseurl }}">{{ ipage.title }}</a>
+                </li>
               {% endif %}
-            {% endfor %}
-          </ul>
-        </div>
+            {% endif %}
+          {% endfor %}
+        </ul>
       </div>
-
     </div>
   </nav>
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,14 @@
 <header>
   <nav>
     <div class="title-bar"  data-responsive-toggle="main-menu" data-hide-for="large" aria-hidden="true">
-      <button class="menu-icon" type="button" data-toggle="main-menu"></button>
-      <div class="title-bar-title">
-        <a href="{{ site.baseurl }}/">{{ site.title }}</a>
+      <div class="title-bar-left">
+        <button class="menu-icon" type="button" data-toggle="main-menu"></button>
+        <div class="title-bar-title">
+          <a href="{{ site.baseurl }}/">{{ site.title }}</a>
+        </div>
+      </div>
+      <div class="title-bar-right">
+        <a href="https://github.com/precice/precice" target="_blank" data-show-count="false" aria-label="Star precice/precice on GitHub"><i class="fab fa-github fa-fw"></i></a>
       </div>
     </div>
 
@@ -22,6 +27,13 @@
               {% endif %}
             {% endif %}
           {% endfor %}
+        </ul>
+      </div>
+      <div class="top-bar-right show-for-large">
+        <ul class="horizontal menu">
+          <li>
+            <a href="https://github.com/precice/precice" target="_blank" data-show-count="false" aria-label="Star precice/precice on GitHub"><i class="fab fa-github fa-fw"></i></a>
+          </li>
         </ul>
       </div>
     </div>

--- a/_sass/_foundation-fouc-fix.scss
+++ b/_sass/_foundation-fouc-fix.scss
@@ -1,0 +1,17 @@
+// This prevents flash of unstyled content (FOUC) of the navigation
+//
+// See https://foundation.zurb.com/sites/docs/responsive-navigation.html#preventing-fouc
+
+.no-js {
+  @include breakpoint($last-mobile-breakpoint down) {
+    .top-bar {
+      display: none;
+    }
+  }
+
+  @include breakpoint($first-desktop-breakpoint) {
+    .title-bar {
+      display: none;
+    }
+  }
+}

--- a/_sass/_settings.scss
+++ b/_sass/_settings.scss
@@ -116,6 +116,8 @@ $breakpoints: (
   xxlarge: 1440px,
 );
 $print-breakpoint: large;
+$last-mobile-breakpoint: medium; // last breakpoint for mobile devices
+$first-desktop-breakpoint: large; // first breakpoint for desktop devices
 $breakpoint-classes: (small medium large);
 
 // 3. The Grid

--- a/_sass/_settings.scss
+++ b/_sass/_settings.scss
@@ -897,3 +897,11 @@ $testimonial-margin: 2rem;
 $testimonial-border: 1px solid get-color(primary);
 $testimonial-radius: $global-radius;
 $testimonial-shadow: none;
+
+// 59. Header settings
+// ---------------
+
+$precice-header-spacing: 3rem;
+$precice-header-icon-font-size: 1.5rem;
+$precice-header-icon-color: $black;
+$precice-header-item-base-size: 2.4rem;

--- a/_sass/precice/_header.scss
+++ b/_sass/precice/_header.scss
@@ -1,4 +1,11 @@
 // This prevents the responsive title-bar to flash up on page load
-body > header .title-bar {
-    display: none;
+body > header {
+    height: 2rem;
+
+    nav { 
+        position: fixed;
+        left: 0;
+        right: 0;
+        width: 100%;
+    }
 }

--- a/_sass/precice/_header.scss
+++ b/_sass/precice/_header.scss
@@ -1,11 +1,55 @@
+$precice-header-spacing: 3rem !default;
+$precice-header-icon-font-size: 1.5rem !default;
+$precice-header-icon-color: $black !default;
+$precice-header-item-base-size: 2.4rem !default;
+
+
 // This prevents the responsive title-bar to flash up on page load
 body > header {
-    height: 2rem;
+    height: $precice-header-spacing;
 
-    nav { 
+    > nav { 
+        z-index: 1; // stay on top of everything
         position: fixed;
         left: 0;
         right: 0;
         width: 100%;
+
+        // responsive title bar
+        > .title-bar {
+            a { height: $precice-header-item-base-size; }
+            .title-bar-right {
+                flex: 0 1 auto;
+                a {
+                    width: $precice-header-item-base-size;
+                    font-size: $precice-header-icon-font-size;
+                    color: inherit;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    > i {
+                        vertical-align: middle;
+                    }
+                }
+            }
+        }
+        // main menu
+        > .top-bar {
+            a { height: $precice-header-item-base-size; }
+            >.top-bar-right {
+                color: $precice-header-icon-color;
+                li {
+                    a {
+                        width: $precice-header-item-base-size;
+                        font-size: $precice-header-icon-font-size;
+                        color: inherit;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        > i{ vertical-align: middle; }
+                    }
+                }
+            }
+        }
     }
 }

--- a/_sass/precice/_header.scss
+++ b/_sass/precice/_header.scss
@@ -35,9 +35,18 @@ body > header {
         }
         // main menu
         > .top-bar {
+            .is-logo {
+                @include breakpoint($last-mobile-breakpoint down) {
+                    display: none;
+                }
+            }
+
             a { height: $precice-header-item-base-size; }
             >.top-bar-right {
                 color: $precice-header-icon-color;
+                @include breakpoint($last-mobile-breakpoint down) {
+                    display: none;
+                }
                 li {
                     a {
                         width: $precice-header-item-base-size;

--- a/css/main.scss
+++ b/css/main.scss
@@ -13,6 +13,7 @@
  */
 @import 'settings';
 @import 'foundation/foundation';
+@import 'foundation-fouc-fix';
 @import 'precice/precice';
 // @import 'motion-ui';
 


### PR DESCRIPTION
Reverting the sticky header from js to css makes the header more robust and removes the sticky delay on certain clients.

Fix #14