### PR TITLE
Reduce Developer Font Size on Small Screens

### DIFF
--- a/_sass/precice/_devlist.scss
+++ b/_sass/precice/_devlist.scss
@@ -13,6 +13,9 @@ $precice-devlist-item-padding: $precice-devlist-padding / 2 $precice-devlist-pad
     border: 1px solid $precice-devlist-border-color;
     border-radius: $precice-devlist-radius;
 
+    @include breakpoint(small down) {
+        font-size: $small-font-size
+    }
 
     // the class to be applied to the first li
     .devlist-first {
@@ -46,6 +49,9 @@ $precice-devlist-item-padding: $precice-devlist-padding / 2 $precice-devlist-pad
             @include xy-cell(shrink, false);
             @include menu-base();
             @include menu-simple();
+            @include breakpoint(small down){
+                @include menu-simple($global-left, $menu-simple-margin*0.5);
+            }
             font-size: larger;
         }
     }


### PR DESCRIPTION
Reduces the font size of the developer list on small screens to prevent wrapping.


Fixed | Previous
--- | --- 
![image](https://user-images.githubusercontent.com/13552216/51178951-7cebde00-18c4-11e9-9b40-c07722b77523.png) | ![image](https://user-images.githubusercontent.com/13552216/51178977-92f99e80-18c4-11e9-9345-7ad5019b5b3c.png)
