### PR TITLE
Basic content for the preCICE Workshop 2020

### DIFF
--- a/09-workshop.md
+++ b/09-workshop.md
@@ -1,0 +1,54 @@
+---
+layout: default
+title: preCICE Workshop 2020
+permalink: /workshop/
+---
+
+# preCICE Workshop 2020
+
+**Save the date!** February 17-18, 2020 at the [Technical University of Munich](https://www.tum.de/nc/en/), [Department of Informatics](http://www.in.tum.de/en/) (campus Garching), [Lecture Hall 2](https://portal.mytum.de/campus/roomfinder/roomfinder_viewmap?mapid=142&roomid=00.04.011@5604).
+
+After meeting you at invited sessions in conferences around Europe,
+it is time that we meet at home, where everything started.
+
+In the two (core) days of the Workshop, we plan to have talks by users and developers
+of preCICE, presenting challenging applications, latest features, as well as the foundations.
+
+## Preliminary schedule
+
+The following is a rough preliminary schedule for the workshop. The main part of the workshop stretches between Monday noon to Tuesday noon. However, we also plan additional events directly before and after the conference.
+
+### Sunday, February 16
+
+If you are in Munich the day before, join us for a hiking trip on the Bavarian Alps. (optional, TBA)
+
+### Monday, February 17
+* 9:00 - 12:00 Hands-on introductory workshop (optional)
+* 12:00 - 13:00 Lunch
+* 13:00 - 19:00 Presentations by users, introduction to new features, invited presentations, and discussions in long coffee breaks
+* 20:00 - 23:00 Dinner
+
+### Tuesday, February 18
+* 9:00 - 12:00 More presentations by users, introduction to new features, invited presentations, and discussions in long coffee breaks
+* 12:00 - 13:00 Lunch
+* 13:00 - 18:00 Hands-on user support (optional)
+
+### Wednesday, February 19
+
+* 9:00 - 18:00 Hands-on user support (if requested)
+
+## Call for contributions
+
+We are looking for speakers and we will offer longer and shorter slots for presentations. The call will follow later this year and announced to our [mailing list](https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice).
+
+## Registration
+
+This is an academic, non-profit conference. However, we still have to collect a small registration fee. Details will be announced later this year and announced to our [mailing list](https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice).
+
+## Getting there
+
+The TUM campus Garching is well connected to the Munich airport (MUC), as well as to the city center and central station. You can reach it using the subway line U6 (station Garching-Forschungszentrum). Have a look at the [Directions page of TUM](https://www.tum.de/en/about-tum/contact-directions/) for more.
+
+## Accommodation
+
+We are preparing a list of recommended hotels, which will be available later this year and announced to our [mailing list](https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice).

--- a/09-workshop.md
+++ b/09-workshop.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: preCICE Workshop 2020
-permalink: /workshop/
+permalink: /preCICE2020/
 ---
 
 # preCICE Workshop 2020

--- a/index.md
+++ b/index.md
@@ -12,6 +12,8 @@ permalink: /
     <strong>News:</strong> (looking for the <a href="https://github.com/precice/precice/releases/latest">latest release on GitHub</a>...)
 </p>
 
+**preCICE Workshop 2020**: Save the date! February 17-18, 2020 in Munich, Germany.
+
 **Give us your feedback**: [please use this form](https://precice.typeform.com/to/IeiyKF), it's important for us!
 
 **preCICE on Twitter**: Follow us at [@preCICE_org](https://twitter.com/preCICE_org) to always stay up-to-date!


### PR DESCRIPTION
This adds:
  * A line in the "news" section of the main page:
    > **preCICE Workshop 2020:** Save the date! February 17-18, 2020 in Munich, Germany.
  * A page "preCICE Workshop 2020" at the very end, as it is common in such cases (it also makes it more noticeable):
  ![Firefox_Screenshot_2019-07-02T15-33-51 496Z](https://user-images.githubusercontent.com/4943683/60526224-2ea28e00-9cf0-11e9-89d7-a42d3094f973.png)

It definitely needs a nice photo and some styling, but I think it is ok for now. The most important is to fix the basic content and to keep the same link until the end.

I am using `permalink: /preCICE2020/` so that:
* People that link to this year's workshop will get the same page next year
* If we later on decide to change the name to "conference" or whatever, this will be the same.
