### PR TITLE
Add hint for citing adapter and link to literature guide

### DIFF
--- a/07-publications.html
+++ b/07-publications.html
@@ -8,7 +8,12 @@ permalink: /publications/
 
   <h1>Publications</h1>
 
-  <h2>To cite preCICE, please use:</h2>
+  <h2>How to cite preCICE?</h2>
+
+  <p>
+    You can cite the preCICE library using the following paper.
+    Please also cite each adapter you use. You can find the respective references in the documentation of our adapters and in our <a href="https://github.com/precice/precice/wiki/Literature-guide">literature guide</a>.
+  </p>
   <div class="publications">
   <article class="publication">
     <header>

--- a/07-publications.html
+++ b/07-publications.html
@@ -12,7 +12,7 @@ permalink: /publications/
 
   <p>
     You can cite the preCICE library using the following paper.
-    Please also cite each adapter you use. You can find the respective references in the documentation of our adapters and in our <a href="https://github.com/precice/precice/wiki/Literature-guide">literature guide</a>.
+    Please also consider citing the adapters you use. You can find the respective references in the documentation of our adapters and in our <a href="https://github.com/precice/precice/wiki/Literature-guide">literature guide</a>.
   </p>
   <div class="publications">
   <article class="publication">

--- a/index.md
+++ b/index.md
@@ -44,7 +44,11 @@ In contrast to other coupling software, preCICE is prepared for the next generat
 
 Download overview slides: [preCICE_Slides.pdf](https://github.com/precice/precice.github.io/tree/master/material/slides/preCICE_Slides.pdf) 
 
-## To cite preCICE, please use:  
+## How to cite preCICE?  
+
+You can cite the preCICE library using the following paper.
+Please also cite each adapter you use. You can find the respective references in the documentation of our adapters and in our [literature guide](https://github.com/precice/precice/wiki/Literature-guide).
+
 <div class="publications">
 <article class="publication">
   <header>

--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ Download overview slides: [preCICE_Slides.pdf](https://github.com/precice/precic
 ## How to cite preCICE?  
 
 You can cite the preCICE library using the following paper.
-Please also cite each adapter you use. You can find the respective references in the documentation of our adapters and in our [literature guide](https://github.com/precice/precice/wiki/Literature-guide).
+Please also consider citing the adapters you use. You can find the respective references in the documentation of our adapters and in our [literature guide](https://github.com/precice/precice/wiki/Literature-guide).
 
 <div class="publications">
 <article class="publication">


### PR DESCRIPTION
# Problem

Academic users cite preCICE, but don't cite the respective adapters (or don't easily find how to cite them).

# Proposed solution

Add a hint next to the "citing preCICE" message (in the home page and in "publications"), refering to the "adapters documentation" (we have different forms) and linking to our literature guide.

![Screenshot from 2019-11-17 11-52-36](https://user-images.githubusercontent.com/4943683/69006553-c7007e80-0930-11ea-95fb-0c894d79bae4.png)


What do you think?